### PR TITLE
Implement replacer for CHANGELOG file

### DIFF
--- a/.github/replacer.json
+++ b/.github/replacer.json
@@ -1,0 +1,7 @@
+[
+  {
+    "search": "{tba}",
+    "replace": "DATETIME",
+    "eval": true
+  }
+]

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -1,0 +1,21 @@
+
+name: Update Changelog
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Replace {tba} placeholder
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: Readme-Workflows/readme-replacer@v1.0.1
+        env:
+          GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
+        with:
+          # Those are all default values and only are shown for demonstration
+          TEMPLATE_FILE: './CHANGELOG.md'
+          COMMIT_FILE: './CHANGELOG.md'
+          CUSTOM_REPLACER_FILE: './.github/replacer.json'

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
     - uses: Readme-Workflows/readme-replacer@v1.0.1
-        env:
-          GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
-        with:
-          TEMPLATE_FILE: './CHANGELOG.md'
-          COMMIT_FILE: './CHANGELOG.md'
-          CUSTOM_REPLACER_FILE: './.github/replacer.json'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        TEMPLATE_FILE: './CHANGELOG.md'
+        COMMIT_FILE: './CHANGELOG.md'
+        CUSTOM_REPLACER_FILE: './.github/replacer.json'

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -4,6 +4,7 @@ name: Update Changelog
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -15,7 +15,6 @@ jobs:
         env:
           GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
         with:
-          # Those are all default values and only are shown for demonstration
           TEMPLATE_FILE: './CHANGELOG.md'
           COMMIT_FILE: './CHANGELOG.md'
           CUSTOM_REPLACER_FILE: './.github/replacer.json'


### PR DESCRIPTION
<!--
    Thank you for opening this Pull request!
    Please make sure to read the info in this PR and to
    provide all nessecary information.

    Not following the template may result in your PR
    being closed without warning!
-->

## Checks
<!-- Please "check" the below options by replacing [ ] with [x] -->

I have...

- [x] read and understood the [Contributing Guidelines][contributing]
- [x] Updated any nessecary files such as the README.md and/or CHANGELOG.md.

## Type of Pull request
<!-- Please "check" the below options by replacing [ ] with [x] -->
<!-- ONLY select one option! -->

- [ ] **Minor Change**  
  This Pull request doesn't break existing configuration.
- [ ] **Major Change**  
  This Pull request will break existing configuration.
- [ ] **Bug fix**  
  This Pull request will fix a (critical) bug.
- [ ] **Documentation**  
  This Pull request only changes documentation (README.md, CHANGELOG.md, etc.)
- [x] **Other:** `Changelog handling` <!-- Replace the __________ with what you changed -->

## Description

Implements the Readme-Replacer action to automatically replace the `{tba}` placeholder in the `CHANGELOG.md` when a release is published.
This saves us some work.

<!-- When your Pull request is related to an issue, mention the ID here -->
Closes #

<!-- Do not edit anything below this line! -->
[contributing]: https://github.com/Readme-Workflows/.github/blob/main/.github/CONTRIBUTING.md
