### PR TITLE
fix: # of activity lines changes according to max_lines property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,33 +107,19 @@ Toolkit.run(
 
     // Recent GitHub Activity content between the comments
     const readmeActivitySection = readmeContent.slice(startIdx, endIdx);
-    if (!readmeActivitySection.length) {
-      content.some((line, idx) => {
-        // User doesn't have 5 public events
-        if (!line) {
-          return true;
-        }
-        readmeContent.splice(startIdx + idx, 0, `${idx + 1}. ${line}`);
-      });
-      tools.log.success("Wrote to README");
-    } else {
-      // It is likely that a newline is inserted after the <!--RECENT_ACTIVITY:start--> comment (code formatter)
-      let count = 0;
-
-      readmeActivitySection.some((line, idx) => {
-        // User doesn't have 5 public events
-        if (!content[count]) {
-          return true;
-        }
-        if (line !== "") {
-          readmeContent[startIdx + idx] = `${count + 1}. ${content[count]}`;
-          count++;
-        }
-      });
-      tools.log.success("Updated README with the recent activity");
+    if (readmeActivitySection.length) {
+      // Remove existing recent activity lines
+      readmeContent.splice(startIdx, endIdx-startIdx);
     }
-
+    content.some((line, idx) => {
+      // User doesn't have 5 public events
+      if (!line) {
+        return true;
+      }
+      readmeContent.splice(startIdx + idx, 0, `${idx + 1}. ${line}`);
+    });
     readmeContent = appendDate(readmeContent);
+    tools.log.success("Updated README with the recent activity");
 
     // Update README
     fs.writeFileSync(readme_file, readmeContent.join("\n"));


### PR DESCRIPTION
<!--
    Thank you for opening this Pull request!
    Please make sure to read the info in this PR and to
    provide all nessecary information.

    Not following the template may result in your PR
    being closed without warning!
-->

## Checks
<!-- Please "check" the below options by replacing [ ] with [x] -->

I have...

- [x] read and understood the [Contributing Guidelines][contributing]
- [x] Updated any nessecary files such as the README.md and/or CHANGELOG.md.

## Type of Pull request
<!-- Please "check" the below options by replacing [ ] with [x] -->
<!-- ONLY select one option! -->

- [ ] **Minor Change**  
  This Pull request doesn't break existing configuration.
- [x] **Major Change**  
  This Pull request will break existing configuration.
- [ ] **Bug fix**  
  This Pull request will fix a (critical) bug.
- [ ] **Documentation**  
  This Pull request only changes documentation (README.md, CHANGELOG.md, etc.)
- [ ] **Other:** `__________` <!-- Replace the __________ with what you changed -->

## Description

This pull request fixes #159.
The number of activity lines will change according to `max_lines` property every time workflow runs.

<!-- When your Pull request is related to an issue, mention the ID here -->
Closes #159 

<!-- Do not edit anything below this line! -->
[contributing]: https://github.com/Readme-Workflows/.github/blob/main/.github/CONTRIBUTING.md
